### PR TITLE
Change logger from an object to a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Types of all options are aviable for typescript users via UserOptions interface.
 
 #### logger
 
-logger is an object which is called by log method with prepared strings with data.
+logger is a function which is called with a parameter containing prepared strings with data.
 
 #### logRequests
 
@@ -101,3 +101,51 @@ which are usually requests fetching schema file.
 
 **Warning:** you should not use this option in production since you can't be sure
 if query with this name is really fetching the schema.
+
+### Updating
+
+#### 0.2.x to 0.3.x
+
+##### Logger
+
+logger is no longer an object responding to .log method,
+so if you are using custom logger object you need to replace
+it with custom logger method.
+
+Example:
+
+0.2.x:
+
+```typescript
+const opts = {
+    logger: customLogger // customLogger has .log() method
+}
+```
+
+0.3.x:
+
+```typescript
+const opts = {
+    logger: (msg) => customLogger.log(msg)
+}
+```
+
+If you were not using custom logger this update should not make any major changes.
+
+##### Prefix
+
+Default prefix was changed from:
+
+```typescript
+`[${Date.now()}]`
+```
+
+to:
+
+```typescript
+`[${Date.now()}] `
+```
+
+Output from logger with default options should remain the same,
+however space between prefix and message was moved from concatenation
+of these strings to prefix itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@est-normalis/simple-apollo-logger",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "A simple logger for Apollo Server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import { stringifiedRequestAttributes } from './formatting'
-import { Request } from './formatting'
 import { defaultOptions, Options, UserOptions } from './options'
 
 export default class ApolloLogExtension {
@@ -37,6 +36,6 @@ export default class ApolloLogExtension {
   public executionDidStart(r: any): void {}
 
   private log(msg: string): void {
-    this.options.logger.log(`${this.options.prefix()} ${msg}`)
+    this.options.logger(`${this.options.prefix()}${msg}`)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import ApolloLogExtension from './extension'
 import { VariableFilter } from './formatting'
-import { Logger, UserOptions } from './options'
+import { UserOptions } from './options'
 
 export default ApolloLogExtension
-export { UserOptions, Logger, VariableFilter }
+export { UserOptions, VariableFilter }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,10 +1,10 @@
 import { VariableFilter } from './formatting'
 
 export const defaultOptions = {
-  logger: console,
+  logger: (msg: string) => console.log(msg),
   logRequests: true,
   logResponses: false,
-  prefix: () => `[${Date.now()}]`,
+  prefix: () => `[${Date.now()}] `,
   variableFilter: {
     keywords: ['password'],
     replacementText: '[FILTERED]'
@@ -13,7 +13,7 @@ export const defaultOptions = {
 }
 
 export interface Options {
-  logger: Logger
+  logger: (msg: string) => any
   logRequests: boolean
   logResponses: boolean
   prefix: () => string
@@ -22,14 +22,10 @@ export interface Options {
 }
 
 export interface UserOptions {
-  logger?: Logger
+  logger?: (msg: string) => any
   logRequests?: boolean
   logResponses?: boolean
   prefix?: () => string
   variableFilter?: VariableFilter | false
   ignoreSchemaRequest?: boolean
-}
-
-export interface Logger {
-  log(msg: string): any
 }


### PR DESCRIPTION
Change logger and its interfaces to allow user customizing it without creating whole object being interface between simple-apollo-logger and external logger (like fe. winston).

Closes #12 